### PR TITLE
Drosky disable cache

### DIFF
--- a/Source/Drosky/Drosky.swift
+++ b/Source/Drosky/Drosky.swift
@@ -145,14 +145,18 @@ public final class Drosky {
         environment: Environment,
         signature: Signature? = nil,
         backgroundSessionID: String = Drosky.backgroundID(),
-        trustedHosts: [String] = []) {
+        trustedHosts: [String] = [],
+        disableCache: Bool = false) {
         
         let serverTrustPolicies = Drosky.serverTrustPoliciesDisablingEvaluationForHosts(trustedHosts)
         
         let serverTrustManager = ServerTrustPolicyManager(policies: serverTrustPolicies)
         
+        let configuration = URLSessionConfiguration.default
+        if disableCache == true { configuration.urlCache = nil }
+        
         networkManager = Alamofire.SessionManager(
-            configuration: URLSessionConfiguration.default,
+            configuration: configuration,
             serverTrustPolicyManager: serverTrustManager
         )
         


### PR DESCRIPTION
Just added a Boolean to offer the possibility to initialize Drosky without Cache. 
With this change you can still use Drosky as you have always used it without any changes.