### PR TITLE
Add a transparent way to generate new signatures on 401

### DIFF
--- a/BSWFoundation.xcodeproj/xcshareddata/xcschemes/BSWFoundationTests.xcscheme
+++ b/BSWFoundation.xcodeproj/xcshareddata/xcschemes/BSWFoundationTests.xcscheme
@@ -41,7 +41,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/BSWFoundation.xcodeproj/xcshareddata/xcschemes/BSWFoundationTests.xcscheme
+++ b/BSWFoundation.xcodeproj/xcshareddata/xcschemes/BSWFoundationTests.xcscheme
@@ -40,7 +40,9 @@
       </CodeCoverageTargets>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "EB2D29E31D55FC0A00F77ABB"

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -165,7 +165,7 @@ private extension APIClient {
     }
 
     func attemptToRecoverFrom<T: Decodable>(error: Swift.Error, request: Request<T>) -> Task<T> {
-        guard error.is401, let newSignatureTask = self.delegate?.apiClientDidReceiveUnauthorized(forRequest: request.endpoint.path, apiClient: self) else {
+        guard (error.is401 || error.is403), let newSignatureTask = self.delegate?.apiClientDidReceiveUnauthorized(forRequest: request.endpoint.path, apiClient: self) else {
             return Task(failure: error)
         }
         newSignatureTask.uponSuccess(on: workerGCDQueue) {
@@ -273,6 +273,16 @@ private extension Swift.Error {
             let apiClientError = self as? APIClient.Error,
             case .failureStatusCode(let statusCode, _) = apiClientError,
             statusCode == 401 else {
+                return false
+        }
+        return true
+    }
+
+    var is403: Bool {
+        guard
+            let apiClientError = self as? APIClient.Error,
+            case .failureStatusCode(let statusCode, _) = apiClientError,
+            statusCode == 403 else {
                 return false
         }
         return true

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -242,18 +242,6 @@ private extension Request {
 public typealias HTTPHeaders = [String: String]
 public struct VoidResponse: Decodable {}
 
-private func dispatchToMainQueueSyncIfPossible(_ handler: @escaping VoidHandler) {
-    if Thread.current.isMainThread {
-        DispatchQueue.main.async {
-            handler()
-        }
-    } else {
-        DispatchQueue.main.sync {
-            handler()
-        }
-    }
-}
-
 private extension Swift.Error {
     var is401: Bool {
         guard

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -44,7 +44,7 @@ open class APIClient {
                 ≈> request.performUserValidator
                 ≈> validateResponse
                 ≈> parseResponse
-        return task.recover(upon: workerGCDQueue) { (error) -> Task<T> in
+        return task.recover(upon: delegateQueue) { (error) -> Task<T> in
             return self.attemptToRecoverFrom(error: error, request: request)
         }
     }

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -163,7 +163,7 @@ private extension APIClient {
     }
 
     func attemptToRecoverFrom<T: Decodable>(error: Swift.Error, request: Request<T>) -> Task<T> {
-        guard (error.is401 || error.is403),
+        guard error.is401,
             request.shouldRetryIfUnauthorized,
             let newSignatureTask = self.delegate?.apiClientDidReceiveUnauthorized(forRequest: request.endpoint.path, apiClient: self) else {
             return Task(failure: error)
@@ -275,16 +275,6 @@ private extension Swift.Error {
             let apiClientError = self as? APIClient.Error,
             case .failureStatusCode(let statusCode, _) = apiClientError,
             statusCode == 401 else {
-                return false
-        }
-        return true
-    }
-
-    var is403: Bool {
-        guard
-            let apiClientError = self as? APIClient.Error,
-            case .failureStatusCode(let statusCode, _) = apiClientError,
-            statusCode == 403 else {
                 return false
         }
         return true

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -86,6 +86,31 @@ extension APIClient {
         case failureStatusCode(Int, Data?)
         case requestCanceled
         case unknownError
+        
+        public var localizedDescription: String {
+            switch self {
+            case .serverError:
+                return "APIClient.Error.serverError"
+            case .malformedURL:
+                return "APIClient.Error.malformedURL"
+            case .malformedParameters:
+                return "APIClient.Error.malformedParameters"
+            case .malformedResponse:
+                return "APIClient.Error.malformedResponse"
+            case .encodingRequestFailed:
+                return "APIClient.Error.encodingRequestFailed"
+            case .multipartEncodingFailed(let reason):
+                return "APIClient.Error.multipartEncodingFailed \(reason)"
+            case .malformedJSONResponse(let error):
+                return "APIClient.Error.malformedJSONResponse \(error)"
+            case .failureStatusCode(let code, _):
+                return "APIClient.Error.failureStatusCode \(code)"
+            case .requestCanceled:
+                return "APIClient.Error.requestCanceled"
+            case .unknownError:
+                return "APIClient.Error.unknownError"
+            }
+        }
     }
 
     public struct Signature {

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -125,13 +125,13 @@ private extension APIClient {
         }
     }
 
-    func validateResponse(response: Response) -> Task<Data> {
+    func validateResponse(response: Response) -> Task<Data>.Result {
         switch response.httpResponse.statusCode {
         case (200..<300):
-            return Task(success: response.data)
+            return .success(response.data)
         default:
             let apiError = APIClient.Error.failureStatusCode(response.httpResponse.statusCode, response.data)
-            return Task(failure: apiError)
+            return .failure(apiError)
         }
     }
 
@@ -232,10 +232,10 @@ extension URLSession: APIClientNetworkFetcher {
 
 private extension Request {
     func performUserValidator(onResponse response: APIClient.Response) -> Task<APIClient.Response> {
-        return Task.async(onCancel: APIClient.Error.requestCanceled, execute: { () in
+        return Task.async(upon: .main, onCancel: APIClient.Error.requestCanceled) { () in
             try self.validator(response)
             return response
-        })
+        }
     }
 }
 

--- a/Source/APIClient/Environment.swift
+++ b/Source/APIClient/Environment.swift
@@ -10,10 +10,12 @@ public struct Request<ResponseType>{
     public typealias Validator = (APIClient.Response) throws -> ()
 
     public let endpoint: Endpoint
+    public let shouldRetryIfUnauthorized: Bool
     public let validator: Validator
-    public init(endpoint: Endpoint, validator: @escaping Validator = { _ in }) {
+    public init(endpoint: Endpoint, shouldRetryIfUnauthorized: Bool = true, validator: @escaping Validator = { _ in }) {
         self.endpoint = endpoint
         self.validator = validator
+        self.shouldRetryIfUnauthorized = shouldRetryIfUnauthorized
     }
 }
 

--- a/Source/Deferred/Deferred+Customizations.swift
+++ b/Source/Deferred/Deferred+Customizations.swift
@@ -115,20 +115,6 @@ extension Task {
             }
         }
     }
-    
-    public func recover(upon executor: Executor, start startNextTask: @escaping(Error) -> Task<Success>) -> Task<Success> {
-        
-        let future: Future<Task<Success>.Result> = andThen(upon: executor) { (result) -> Task<Success> in
-            do {
-                let value = try result.get()
-                return Task<Success>(success: value)
-            } catch let error {
-                return startNextTask(error)
-            }
-        }
-        
-        return Task<Success>(future)
-    }
 }
 
 extension Task.Result {

--- a/Tests/APIClient/APIClientTests.swift
+++ b/Tests/APIClient/APIClientTests.swift
@@ -116,30 +116,7 @@ class APIClientTests: XCTestCase {
         let ipRequest = BSWFoundation.Request<HTTPBin.Responses.IP>(
             endpoint: HTTPBin.API.ip
         )
-        
-        var catchedError: Swift.Error?
-        let task = sut.perform(ipRequest)
-        let exp = self.expectation(description: "Extract from Future")
-        task.upon(.main) { (result) in
-            switch result {
-            case .failure(let error):
-                catchedError = error
-            case .success:
-                break
-            }
-            exp.fulfill()
-        }
-        self.waitForExpectations(timeout: 10) { (timeoutError) in
-            if let timeoutError = timeoutError {
-                catchedError = timeoutError
-            }
-        }
-
-        guard catchedError == nil else {
-            print(catchedError!.localizedDescription)
-            XCTFail()
-            return
-        }
+        let _ = try waitAndExtractValue(sut.perform(ipRequest))
     }
 }
 

--- a/Tests/APIClient/APIClientTests.swift
+++ b/Tests/APIClient/APIClientTests.swift
@@ -36,7 +36,7 @@ class APIClientTests: XCTestCase {
         let _ = try self.waitAndExtractValue(getTask, timeout: 3)
     }
 
-    func testGETCancel() throws {
+    func _testGETCancel() throws {
         let ipRequest = BSWFoundation.Request<HTTPBin.Responses.IP>(
             endpoint: HTTPBin.API.ip
         )
@@ -72,7 +72,7 @@ class APIClientTests: XCTestCase {
         progress = nil
     }
 
-    func testUploadCancel() {
+    func _testUploadCancel() {
         guard let url = Bundle(for: type(of: self)).url(forResource: "cannavaro", withExtension: "jpg") else {
             XCTFail()
             return

--- a/Tests/APIClient/APIClientTests.swift
+++ b/Tests/APIClient/APIClientTests.swift
@@ -116,7 +116,30 @@ class APIClientTests: XCTestCase {
         let ipRequest = BSWFoundation.Request<HTTPBin.Responses.IP>(
             endpoint: HTTPBin.API.ip
         )
-        let _ = try waitAndExtractValue(sut.perform(ipRequest))
+        
+        var catchedError: Swift.Error?
+        let task = sut.perform(ipRequest)
+        let exp = self.expectation(description: "Extract from Future")
+        task.upon(.main) { (result) in
+            switch result {
+            case .failure(let error):
+                catchedError = error
+            case .success:
+                break
+            }
+            exp.fulfill()
+        }
+        self.waitForExpectations(timeout: 10) { (timeoutError) in
+            if let timeoutError = timeoutError {
+                catchedError = timeoutError
+            }
+        }
+
+        guard catchedError == nil else {
+            print(catchedError!.localizedDescription)
+            XCTFail()
+            return
+        }
     }
 }
 

--- a/Tests/APIClient/APIClientTests.swift
+++ b/Tests/APIClient/APIClientTests.swift
@@ -36,7 +36,7 @@ class APIClientTests: XCTestCase {
         let _ = try self.waitAndExtractValue(getTask, timeout: 3)
     }
 
-    func _testGETCancel() throws {
+    func testGETCancel() throws {
         let ipRequest = BSWFoundation.Request<HTTPBin.Responses.IP>(
             endpoint: HTTPBin.API.ip
         )
@@ -72,7 +72,7 @@ class APIClientTests: XCTestCase {
         progress = nil
     }
 
-    func _testUploadCancel() {
+    func testUploadCancel() {
         guard let url = Bundle(for: type(of: self)).url(forResource: "cannavaro", withExtension: "jpg") else {
             XCTFail()
             return

--- a/Tests/APIClient/APIClientTests.swift
+++ b/Tests/APIClient/APIClientTests.swift
@@ -123,7 +123,7 @@ class APIClientTests: XCTestCase {
 import Deferred
 
 private class MockAPIClientDelegate: APIClientDelegate {
-    func apiClientDidReceiveUnauthorized(forRequest atPath: String, apiClient: APIClient) -> Task<APIClient.Signature>? {
+    func apiClientDidReceiveUnauthorized(forRequest atPath: String, apiClient: APIClient) -> Task<()>? {
         failedPath = atPath
         return nil
     }
@@ -143,8 +143,9 @@ private class Network401Fetcher: APIClientNetworkFetcher {
 }
 
 private class MockAPIClientDelegateThatGeneratesNewSignature: APIClientDelegate {
-    func apiClientDidReceiveUnauthorized(forRequest atPath: String, apiClient: APIClient) -> Task<APIClient.Signature>? {
-        return Task(success: APIClient.Signature(name: "JWT", value: "Daenerys Targaryen is the True Queen"))
+    func apiClientDidReceiveUnauthorized(forRequest atPath: String, apiClient: APIClient) -> Task<()>? {
+        apiClient.addSignature(APIClient.Signature(name: "JWT", value: "Daenerys Targaryen is the True Queen"))
+        return Task(success: ())
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,9 @@
 default_platform(:ios)
 
-cocoapods(try_repo_update_on_error: true)
-setup_jenkins
+before_all do |lane, options|
+  cocoapods(try_repo_update_on_error: true)
+  setup_jenkins(derived_data_path: "./derivedData")
+end
 
 platform :ios do
   desc "Execute unit tests"
@@ -12,4 +14,8 @@ platform :ios do
       devices: ["iPhone X"],
       )
   end
+end
+
+after_all do |lane, options|
+  clear_derived_data(derived_data_path: "./derivedData")
 end


### PR DESCRIPTION
This breaking change modifies the current signature for `apiClientDidReceiveUnauthorized` which gives the delegate a chance to optionally return new credentials. In case these credentials are provided, the request is retried.

~~This PR brakes Request cancellations due to https://github.com/bignerdranch/Deferred/issues/287~~