### PR TITLE
Improve the way APIClient.Errors are localized to the final user

### DIFF
--- a/Sources/BSWFoundation/APIClient/APIClient+Error.swift
+++ b/Sources/BSWFoundation/APIClient/APIClient+Error.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+extension APIClient.Error: LocalizedError {
+    public var errorDescription: String? {
+        let apiClientError: String = {
+            switch self {
+            case .malformedURL:
+                return "malformedURL"
+            case .malformedParameters:
+                return "malformedParameters"
+            case .malformedResponse:
+                return "malformedResponse"
+            case .encodingRequestFailed:
+                return "encodingRequestFailed"
+            case .multipartEncodingFailed(let reason):
+                return "multipartEncodingFailed Reason: \(reason)"
+            case .malformedJSONResponse(let error):
+                return "malformedJSONResponse Error: \(error.localizedDescription)"
+            case .failureStatusCode(let statusCode, let data):
+                if let data = data, let prettyError = JSONParser.parseDataAsJSONPrettyPrint(data) {
+                    return "FailureStatusCode: \(statusCode), Message: \(prettyError)"
+                } else {
+                    return "FailureStatusCode Status Code: \(statusCode)"
+                }
+            case .requestCanceled:
+                return "requestCanceled"
+            case .unknownError:
+                return "unknownError"
+            }
+        }()
+        let localizedError = ShimError().localizedDescription
+        let pattern = "\\(.*\\)" //everything between ( and )
+        return localizedError.replacingOccurrences(
+            of: pattern,
+            with: "(BSWFoundation.APIClient.Error.\(apiClientError))",
+            options: .regularExpression
+        )
+    }
+    
+    /// This is here just to get the "The operation couldn’t be completed" message localized
+    private struct ShimError: Error {}
+}

--- a/Sources/BSWFoundation/APIClient/APIClient+Error.swift
+++ b/Sources/BSWFoundation/APIClient/APIClient+Error.swift
@@ -20,7 +20,7 @@ extension APIClient.Error: LocalizedError {
                 if let data = data, let prettyError = JSONParser.parseDataAsJSONPrettyPrint(data) {
                     return "FailureStatusCode: \(statusCode), Message: \(prettyError)"
                 } else {
-                    return "FailureStatusCode Status Code: \(statusCode)"
+                    return "FailureStatusCode: \(statusCode)"
                 }
             case .requestCanceled:
                 return "requestCanceled"

--- a/Sources/BSWFoundation/APIClient/APIClient.swift
+++ b/Sources/BSWFoundation/APIClient/APIClient.swift
@@ -82,7 +82,6 @@ open class APIClient {
 extension APIClient {
 
     public enum Error: Swift.Error {
-        case serverError
         case malformedURL
         case malformedParameters
         case malformedResponse

--- a/Sources/BSWFoundation/Parse/JSONParser.swift
+++ b/Sources/BSWFoundation/Parse/JSONParser.swift
@@ -34,7 +34,14 @@ public enum JSONParser {
 
     public static func parseDataAsJSONPrettyPrint(_ data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: JSONParser.Options) else { return nil }
-        guard let prettyPrintedData = try? JSONSerialization.data(withJSONObject: json, options: .init()) else { return nil }
+        let options: JSONSerialization.WritingOptions = {
+            if #available(iOS 13.0, *) {
+                return [.fragmentsAllowed,.withoutEscapingSlashes]
+            } else {
+                return [.fragmentsAllowed]
+            }
+        }()
+        guard let prettyPrintedData = try? JSONSerialization.data(withJSONObject: json, options: options) else { return nil }
         return String(data: prettyPrintedData, encoding: .utf8)
     }
 

--- a/Sources/BSWFoundation/Parse/JSONParser.swift
+++ b/Sources/BSWFoundation/Parse/JSONParser.swift
@@ -35,7 +35,7 @@ public enum JSONParser {
     public static func parseDataAsJSONPrettyPrint(_ data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: JSONParser.Options) else { return nil }
         let options: JSONSerialization.WritingOptions = {
-            if #available(iOS 13.0, *) {
+            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
                 return [.fragmentsAllowed,.withoutEscapingSlashes]
             } else {
                 return [.fragmentsAllowed]

--- a/Tests/BSWFoundationTests/APIClient/APIClientErrorTests.swift
+++ b/Tests/BSWFoundationTests/APIClient/APIClientErrorTests.swift
@@ -1,0 +1,18 @@
+
+import XCTest
+@testable import BSWFoundation
+
+class APIClientErrorTests: XCTestCase {
+    func testErrorPrinting_encodingRequestFailed() {
+        let localizedDescription = APIClient.Error.encodingRequestFailed.localizedDescription
+        XCTAssert(localizedDescription == "The operation couldn’t be completed. (BSWFoundation.APIClient.Error.encodingRequestFailed)")
+    }
+    
+    func testErrorPrinting_serverStatusCode() {
+        let errorMessageData =  """
+        ["Please try again"]
+        """.data(using: .utf8)
+        let localizedDescription = APIClient.Error.failureStatusCode(400, errorMessageData).localizedDescription
+        XCTAssert(localizedDescription == "The operation couldn’t be completed. (BSWFoundation.APIClient.Error.FailureStatusCode: 400, Message: [\"Please try again\"])")
+    }
+}

--- a/Tests/BSWFoundationTests/APIClient/APIClientErrorTests.swift
+++ b/Tests/BSWFoundationTests/APIClient/APIClientErrorTests.swift
@@ -15,4 +15,12 @@ class APIClientErrorTests: XCTestCase {
         let localizedDescription = APIClient.Error.failureStatusCode(400, errorMessageData).localizedDescription
         XCTAssert(localizedDescription == "The operation couldn’t be completed. (BSWFoundation.APIClient.Error.FailureStatusCode: 400, Message: [\"Please try again\"])")
     }
+    
+    func testErrorPrinting_serverStatusCode_2() {
+        let errorMessageData =  """
+        "Please try again"
+        """.data(using: .utf8)
+        let localizedDescription = APIClient.Error.failureStatusCode(400, errorMessageData).localizedDescription
+        XCTAssert(localizedDescription == "The operation couldn’t be completed. (BSWFoundation.APIClient.Error.FailureStatusCode: 400, Message: \"Please try again\")")
+    }
 }


### PR DESCRIPTION
- [x] Check why `JSONParser.prettyPrint` crashes with some data