### PR TITLE
Let's not buffer for eternity

### DIFF
--- a/Sources/BSWFoundation/AsyncStream/AsyncStreamDispatcher.swift
+++ b/Sources/BSWFoundation/AsyncStream/AsyncStreamDispatcher.swift
@@ -17,7 +17,7 @@ public actor AsyncStreamDispatcher<Event: AsyncStreamNamedEvent> {
     
     public func subscribe(to events: Set<Event.Name>) -> AsyncStream<Event> {
         let id = UUID()
-        let (stream, continuation) = AsyncStream<Event>.makeStream(bufferingPolicy: .unbounded)
+        let (stream, continuation) = AsyncStream<Event>.makeStream(bufferingPolicy: .bufferingNewest(1))
         
         for eventName in events {
             var subscriber: [UUID: AsyncStream<Event>.Continuation]


### PR DESCRIPTION
This was causing a crash on Android devices where the app wouldn't even report the crash back to Firebase