### PR TITLE
feat: add observation extension 

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: set -o pipefail && xcodebuild test -scheme BSWFoundation -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' | xcbeautify --renderer github-actions
+        run: set -o pipefail && xcodebuild test -scheme BSWFoundation -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' | xcbeautify --renderer github-actions
 
   android-build:
     runs-on: mobile

--- a/Package.swift
+++ b/Package.swift
@@ -44,11 +44,11 @@ if !zero {
 let package = Package(
     name: "BSWFoundation",
     platforms: [
-        .iOS(.v16),
-        .tvOS(.v16),
-        .macOS(.v14),
-        .macCatalyst(.v16),
-        .watchOS(.v9),
+        .iOS(.v17),
+        .tvOS(.v17),
+        .macOS(.v15),
+        .macCatalyst(.v17),
+        .watchOS(.v10),
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     platforms: [
         .iOS(.v16),
         .tvOS(.v16),
-        .macOS(.v13),
+        .macOS(.v14),
         .macCatalyst(.v16),
         .watchOS(.v9),
     ],

--- a/Sources/BSWFoundation/Extensions/Observation+Ext.swift
+++ b/Sources/BSWFoundation/Extensions/Observation+Ext.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 
+@MainActor
 extension Observable where Self: AnyObject & Sendable {
     
     public func stream<Value: Sendable>(

--- a/Sources/BSWFoundation/Extensions/Observation+Ext.swift
+++ b/Sources/BSWFoundation/Extensions/Observation+Ext.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Observation
 
-@MainActor
 extension Observable where Self: AnyObject & Sendable {
     
     public func stream<Value: Sendable>(

--- a/Sources/BSWFoundation/Extensions/Observation+Ext.swift
+++ b/Sources/BSWFoundation/Extensions/Observation+Ext.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Observation
+
+@MainActor
+extension Observable where Self: AnyObject & Sendable {
+    
+    public func stream<Value: Sendable>(
+        for keyPath: KeyPath<Self, Value>
+    ) -> AsyncStream<Value> {
+        let box = ObservationBox()
+        nonisolated(unsafe) let keyPath = keyPath
+        
+        return AsyncStream(Value.self) { continuation in
+            @Sendable func track(object: Self) {
+                Observation.withObservationTracking { [weak object] in
+                    guard let self = object, !box.isCancelled else { return }
+                    let value = self[keyPath: keyPath]
+                    continuation.yield(value)
+                } onChange: { [weak object] in
+                    DispatchQueue.main.async {
+                        guard let self = object, !box.isCancelled else { return }
+                        track(object: self)
+                    }
+                }
+            }
+            
+            continuation.onTermination = { _ in
+                box.isCancelled = true
+            }
+            
+            track(object: self)
+        }
+    }
+}
+
+extension AsyncStream where Element: Equatable {
+  public func until(_ e: Element) async {
+    var iterator = self.makeAsyncIterator()
+    while let value = await iterator.next() {
+      if e == value {
+        return
+      }
+    }
+  }
+}
+
+private final class ObservationBox: @unchecked Sendable {
+    var isCancelled = false
+}

--- a/Tests/BSWFoundationTests/Extensions/ObservationTests.swift
+++ b/Tests/BSWFoundationTests/Extensions/ObservationTests.swift
@@ -1,0 +1,29 @@
+
+import Testing
+import Observation
+
+@Suite
+struct ObservationTests {
+    
+    @Observable
+    @MainActor
+    class ViewModel {
+        var isReady: Bool = false
+        func setIsReady() {
+            isReady = true
+        }
+    }
+    
+    @MainActor
+    @Test
+    func itCompletesCorrectly() async throws {
+        let viewModel = ViewModel()
+        Task {
+            try await Task.sleep(for: .milliseconds(20))
+            viewModel.setIsReady()
+        }
+        #expect(viewModel.isReady == false)
+        await viewModel.stream(for: \.isReady).until(true)
+        #expect(viewModel.isReady)
+    }
+}


### PR DESCRIPTION
Introduce `Observation+Ext.swift` to extend `Observable` objects with a `stream` method for keyPath-driven value observation using `AsyncStream`. This feature enables observing changes in observable objects more
conveniently, particularly in asynchronous contexts.

Additionally, `AsyncStream` is extended to include an `until` method, allowing iteration to continue until a specified value is encountered, improving testing capabilities.

With these changes, new unit tests are created in `ObservationTests.swift` to ensure that the observable streams function correctly.

Also, update `Package.swift` to support macOS version 14, ensuring broader adoption and compatibility with recent macOS features.
